### PR TITLE
fix: Support disable other options

### DIFF
--- a/components/QuestionnaireRenderer.tsx
+++ b/components/QuestionnaireRenderer.tsx
@@ -1,6 +1,6 @@
 import { SelectableItem, Text, View } from "@/components/themed";
 import { InspectionQuestion, OptionType, ResourceType } from "@/types";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Control,
   Controller,
@@ -31,6 +31,7 @@ export interface ISelectableItem {
   text?: string;
   resourceType?: ResourceType;
   statusColor?: string;
+  disableOtherOptions?: boolean;
 }
 
 /** Utils */
@@ -52,6 +53,7 @@ const formatOptionsForSelectableItems = ({
         required,
         group,
         statusColor,
+        disableOtherOptions,
       }) => ({
         value: id,
         label: name,
@@ -64,6 +66,7 @@ const formatOptionsForSelectableItems = ({
         group,
         resourceType,
         statusColor,
+        disableOtherOptions,
       }),
     )
     .sort((a, b) => a.value - b.value) || [];
@@ -77,6 +80,7 @@ export interface FormStateOption {
   resourceType?: string;
   optionType?: string;
   statusColor?: string;
+  disableOtherOptions?: boolean;
 }
 
 const prepareOption = ({
@@ -88,6 +92,7 @@ const prepareOption = ({
     resourceType,
     optionType,
     statusColor,
+    disableOtherOptions,
   },
   text,
 }: {
@@ -102,6 +107,7 @@ const prepareOption = ({
   text,
   optionType,
   statusColor,
+  disableOtherOptions,
 });
 
 const groupOptions = (
@@ -122,37 +128,49 @@ const QuestionnaireRenderer = ({
 }: QuestionnaireRendererProps) => {
   const { t } = useTranslation();
   const hasRequiredOptions = question?.options?.some((o) => o.required);
-  const { control, getValues, setValue } = methods;
+  const { control, getValues, setValue, watch } = methods;
   const name = question.id.toString();
   const formattedOptions: ISelectableItem[] =
     formatOptionsForSelectableItems(question);
   const hasGroup = formattedOptions.every((option) => option.group);
   const groupedOptions = groupOptions(formattedOptions);
+  const currentValues = watch(name);
 
-  const renderOptions = (option: ISelectableItem) => {
-    return (
-      <>
-        {question.typeField === "multiple" && (
-          <ControlledCheckbox
-            setValue={setValue}
-            getValues={getValues}
-            name={name}
-            control={control}
-            option={option}
-          />
-        )}
-        {question.typeField === "list" && (
-          <ControlledList
-            getValues={getValues}
-            setValue={setValue}
-            name={name}
-            control={control}
-            option={option}
-          />
-        )}
-      </>
-    );
-  };
+  const renderOptions = useCallback(
+    (option: ISelectableItem) => {
+      return (
+        <>
+          {question.typeField === "multiple" && (
+            <ControlledCheckbox
+              setValue={setValue}
+              getValues={getValues}
+              name={name}
+              control={control}
+              option={option}
+              currentValues={currentValues}
+            />
+          )}
+          {question.typeField === "list" && (
+            <ControlledList
+              getValues={getValues}
+              setValue={setValue}
+              name={name}
+              control={control}
+              option={option}
+            />
+          )}
+        </>
+      );
+    },
+    [currentValues],
+  );
+
+  console.log(
+    (currentValues || []).length,
+    "values>>",
+    "rerender",
+    "-------------------",
+  );
 
   return (
     <FormProvider {...methods}>
@@ -201,16 +219,31 @@ const ControlledCheckbox = ({
   option,
   getValues,
   setValue,
+  currentValues,
 }: {
   name: string;
   control: Control<FieldValues>;
   option: ISelectableItem;
   setValue: UseFormSetValue<FieldValues>;
   getValues: UseFormGetValues<FieldValues>;
+  currentValues: FormStateOption[];
 }) => {
-  const [itemsChecked, setItemsChecked] = useState(getValues(name) || []);
+  const [itemsChecked, setItemsChecked] = useState(currentValues || []);
   const isSelected = itemsChecked.some(
-    (item: ISelectableItem) => item.value === option.value,
+    (item: FormStateOption) => item.value === option.value,
+  );
+
+  useEffect(() => {
+    setItemsChecked(currentValues);
+  }, [currentValues]);
+
+  console.log(
+    itemsChecked.length,
+    currentValues.length,
+    "items>>>",
+    option.value,
+    option.label,
+    "rerender",
   );
 
   const onChange = (text: string) => {
@@ -230,12 +263,27 @@ const ControlledCheckbox = ({
       setValue(name, valuesToSave);
       setItemsChecked(valuesToSave);
     } else {
-      const valuesToSave = [...values, prepareOption({ option, text })];
+      let valuesToSave = [...values, prepareOption({ option, text })];
+
+      if (option.disableOtherOptions) {
+        valuesToSave = [prepareOption({ option, text })];
+      } else {
+        if (itemsChecked.some((item) => item.disableOtherOptions)) {
+          valuesToSave = values;
+        }
+      }
 
       setValue(name, valuesToSave);
       setItemsChecked(valuesToSave);
     }
   };
+
+  const conditionalDisablingItem = itemsChecked.find(
+    (item) => item.disableOtherOptions === true,
+  );
+  const shouldDisable =
+    !!conditionalDisablingItem &&
+    option.value !== conditionalDisablingItem?.value;
 
   return (
     <Controller
@@ -254,6 +302,7 @@ const ControlledCheckbox = ({
             type="checkbox"
             image={option.image}
             defaultText={isSelected.text}
+            disabled={!!shouldDisable}
           />
         );
       }}

--- a/components/themed/SelectableItem.tsx
+++ b/components/themed/SelectableItem.tsx
@@ -61,8 +61,8 @@ export function SelectableItem({
 
   return (
     <TouchableOpacity
-      onPress={handleChange}
-      className={`flex p-4 mb-2 rounded-md ${checked ? "bg-green-400" : "bg-gray-400"}`}
+      onPress={!disabled ? handleChange : () => {}}
+      className={`flex p-4 mb-2 rounded-md ${checked ? "bg-green-400" : "bg-gray-400"} ${disabled && "opacity-50"}`}
     >
       <View className="flex bg-transparent">
         {image && (
@@ -72,7 +72,7 @@ export function SelectableItem({
         )}
         <View className="flex flex-row bg-transparent">
           <Pressable
-            className="bg-white mr-2"
+            className="mr-2"
             {...other}
             disabled={disabled}
             // Announces "checked" status and "checkbox" as the focused element
@@ -81,12 +81,12 @@ export function SelectableItem({
             style={[
               styles.root,
               style,
+              disabled && styles.disabled,
               checked && styles.checked,
               !!color && {
                 backgroundColor: checked ? color : undefined,
                 borderColor: color,
               },
-              disabled && styles.disabled,
               checked && disabled && styles.checkedAndDisabled,
             ]}
             onPress={handleChange}
@@ -183,6 +183,7 @@ const boxStyles = StyleSheet.create({
   disabled: {
     borderColor: disabledGrayColor,
     backgroundColor: "transparent",
+    opacity: 0.5,
   },
   checkedAndDisabled: {
     backgroundColor: disabledCheckedGrayColor,

--- a/types/SelectableItemProps.ts
+++ b/types/SelectableItemProps.ts
@@ -75,4 +75,9 @@ export type SelectableItemProps = ViewProps & {
    * Text to render when inputs are rendered
    */
   defaultText?: string;
+  /**
+   * If an item with this option is selected,
+   * all the other options should be disabled
+   */
+  disableOtherOptions?: boolean;
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -42,6 +42,7 @@ export interface Option {
   optionType: OptionType;
   group: string;
   statusColor?: string;
+  disableOtherOptions?: boolean;
 }
 
 export interface Image {


### PR DESCRIPTION
We now support `disableOtherOptions` in the `SelectableItem` component. Ref [308](https://denguechat.atlassian.net/browse/DNG-308).

**Demo**
<img width="333" alt="Screenshot 2024-09-25 at 14 03 21" src="https://github.com/user-attachments/assets/b0be46ba-deea-42b8-b198-b03adc74685f">
