### PR TITLE
fix: Add padding to selectable item

### DIFF
--- a/components/themed/SelectableItem.tsx
+++ b/components/themed/SelectableItem.tsx
@@ -86,7 +86,7 @@ export function SelectableItem({
             )}
           </View>
         )}
-        <View className="flex flex-row bg-transparent">
+        <View className="flex flex-row bg-transparent text-wrap">
           <Pressable
             className="mr-2"
             {...other}
@@ -109,7 +109,7 @@ export function SelectableItem({
           >
             {checked && checkedView}
           </Pressable>
-          <Text className="text-sky-400 font-medium text-sm/[17px] flex-grow">
+          <Text className="text-sky-400 font-medium text-sm/[17px] flex-grow pr-6">
             {label}
             {required && "*"}
           </Text>


### PR DESCRIPTION
This PR fixes [428](https://denguechat.atlassian.net/browse/DNG-428) by adding right-padding to the items.

<img width="351" alt="Screenshot 2024-11-14 at 16 50 11" src="https://github.com/user-attachments/assets/863bdfaa-8549-4b1f-b5a1-f8e8b8b64596">
