### PR TITLE
feat: add houses list to offline mode

### DIFF
--- a/app/(auth)/(visit)/select-house.tsx
+++ b/app/(auth)/(visit)/select-house.tsx
@@ -32,8 +32,9 @@ export default function SelectHouseScreen() {
   const router = useRouter();
 
   const { user } = useAuth();
-  const { setVisitData, questionnaire, language } = useVisit();
-  const { initialiseCurrentVisit } = useVisitStore();
+  const { setVisitData, questionnaire, language, isConnected } = useVisit();
+  const { initialiseCurrentVisit, storedHouseList, saveHouseList } =
+    useVisitStore();
 
   const updateHouse = async () => {
     const catchAll =
@@ -68,12 +69,18 @@ export default function SelectHouseScreen() {
   }, [isFocused]);
 
   useEffect(() => {
-    if (data) {
+    if (isConnected && data) {
       const deserializedData = deserialize<House>(data);
       if (!deserializedData || !Array.isArray(deserializedData)) return;
 
       setHouseOptions(deserializedData);
       setHouseSelected(undefined);
+
+      // always save the house list
+      saveHouseList(deserializedData);
+    }
+    if (!isConnected && storedHouseList) {
+      setHouseOptions(storedHouseList);
     }
   }, [data]);
 

--- a/hooks/useVisitStore.ts
+++ b/hooks/useVisitStore.ts
@@ -1,5 +1,5 @@
 import { ISelectableItem } from "@/components/QuestionnaireRenderer";
-import { VisitId } from "@/types";
+import { House, VisitId } from "@/types";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { NetworkState } from "expo-network";
 import { create } from "zustand";
@@ -40,6 +40,8 @@ interface VisitStore {
   setNetworkState: (state: NetworkState) => void;
   cleanUpStoredVisit: (visit: any) => void;
   cleanUpVisits: () => void;
+  storedHouseList: House[];
+  saveHouseList: (houses: House[]) => void;
 }
 
 export const useVisitStore = create<VisitStore>()(
@@ -52,6 +54,7 @@ export const useVisitStore = create<VisitStore>()(
         visitMap: {},
         visitMetadata: {},
         selectedCase: "house",
+        storedHouseList: [],
         /**
          * All visits that were not published to the backed
          * will be save in this array as QuestionnaireState
@@ -98,6 +101,10 @@ export const useVisitStore = create<VisitStore>()(
             ++state.visitMetadata[state.visitId].inspectionIdx;
           }),
         setNetworkState: (networkState) => set((state) => ({ networkState })),
+        saveHouseList: (houses) =>
+          set((state) => {
+            state.storedHouseList = houses;
+          }),
         cleanUpStoredVisit: (visit) =>
           set((state) => {
             const index = state.storedVisits.findIndex(


### PR DESCRIPTION
This PR saves the house list to local storage of every load, so that it's available later in offline mode
