### PR TITLE
fix: bump expo-image-picker to remove android permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "expo-font": "~12.0.10",
     "expo-image": "~1.13.0",
     "expo-image-manipulator": "~12.0.5",
-    "expo-image-picker": "~15.0.7",
+    "expo-image-picker": "16.0.3",
     "expo-linking": "~6.3.1",
     "expo-localization": "~15.0.3",
     "expo-location": "~17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4890,6 +4890,11 @@ expo-image-loader@~4.7.0:
   resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-4.7.0.tgz#d403106822de80bda12d644c82b7a3b7983c0f0b"
   integrity sha512-cx+MxxsAMGl9AiWnQUzrkJMJH4eNOGlu7XkLGnAXSJrRoIiciGaKqzeaD326IyCTV+Z1fXvIliSgNW+DscvD8g==
 
+expo-image-loader@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-5.0.0.tgz#4f58a21ab26e40d6fccc211b664fd9fe21a5dcb8"
+  integrity sha512-Eg+5FHtyzv3Jjw9dHwu2pWy4xjf8fu3V0Asyy42kO+t/FbvW/vjUixpTjPtgKQLQh+2/9Nk4JjFDV6FwCnF2ZA==
+
 expo-image-manipulator@~12.0.5:
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/expo-image-manipulator/-/expo-image-manipulator-12.0.5.tgz#e3dd2810d27025705f73523cd4ba47b0d091a662"
@@ -4897,12 +4902,12 @@ expo-image-manipulator@~12.0.5:
   dependencies:
     expo-image-loader "~4.7.0"
 
-expo-image-picker@~15.0.7:
-  version "15.0.7"
-  resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-15.0.7.tgz#eb25abfdb03cb940f0418add3d9814439526b025"
-  integrity sha512-u8qiPZNfDb+ap6PJ8pq2iTO7JKX+ikAUQ0K0c7gXGliKLxoXgDdDmXxz9/6QdICTshJBJlBvI0MwY5NWu7A/uw==
+expo-image-picker@16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-16.0.3.tgz#8b096777b4455272a3cb0dccfa3cee89b81bb13c"
+  integrity sha512-c4IOqIQOtx8puWWU4fVsJhuGiAhH6gAIdrVzhimOXSEUHnfxCckRYzvznbd/0cuvaA5y9H0CSYrxpTUc/0WNVw==
   dependencies:
-    expo-image-loader "~4.7.0"
+    expo-image-loader "~5.0.0"
 
 expo-image@~1.13.0:
   version "1.13.0"


### PR DESCRIPTION
This PR is a workaround to fix [DNG-591](https://denguechat.atlassian.net/browse/DNG-591), as the new `expo-image-picker` relase @ 16.0.3 [removes](https://github.com/fobos531/expo/blob/main/packages/expo-image-picker/CHANGELOG.md#1600--2024-10-22) the permissions.