### PR TITLE
Add confirmation modal before creating a new site

### DIFF
--- a/app/(auth)/(visit)/new-house.tsx
+++ b/app/(auth)/(visit)/new-house.tsx
@@ -91,8 +91,8 @@ export default function NewHouse() {
     const code = getValues("siteNumber");
 
     Alert.alert(
-      t("visit.newHouse.confirmSiteCodeTitle"),
-      t("visit.newHouse.confirmSiteCodeDescription", { code }),
+      t("visit.newHouse.confirmSiteNumberTitle"),
+      t("visit.newHouse.confirmSiteNumberDescription", { code }),
       [
         {
           text: "Cancel",

--- a/assets/i18n/en-US.json
+++ b/assets/i18n/en-US.json
@@ -199,7 +199,12 @@
         "addressPlaceholder": "Enter the site address",
         "confirmLocation": "Confirm location",
         "noConnection": "You have no connection",
-        "noMapConnection": "We cannot load the map because you have no internet connection."
+        "noMapConnection": "We cannot load the map because you have no internet connection.",
+        "confirmSiteCodeTitle": "Confirm site code",
+        "confirmSiteCodeDescription": "Confirm with your brigade facilitator that the site you are about to visit corresponds to site code {{code}}",
+        "validation": {
+          "siteCodeRegexError": "Field must only contain upper case letters and numbers"
+        }
       },
       "summary": {
         "siteStatus": "Status of the site",

--- a/assets/i18n/en-US.json
+++ b/assets/i18n/en-US.json
@@ -200,8 +200,8 @@
         "confirmLocation": "Confirm location",
         "noConnection": "You have no connection",
         "noMapConnection": "We cannot load the map because you have no internet connection.",
-        "confirmSiteCodeTitle": "Confirm site code",
-        "confirmSiteCodeDescription": "Confirm with your brigade facilitator that the site you are about to visit corresponds to site code {{code}}",
+        "confirmSiteNumberTitle": "Confirm site code",
+        "confirmSiteNumberDescription": "Confirm with your brigade facilitator that the site you are about to visit corresponds to site code {{code}}",
         "validation": {
           "siteCodeRegexError": "Field must only contain upper case letters and numbers"
         }

--- a/assets/i18n/es-ES.json
+++ b/assets/i18n/es-ES.json
@@ -200,8 +200,8 @@
         "confirmLocation": "Confirmar ubicación",
         "noConnection": "No tienes conexión",
         "noMapConnection": "No podemos cargar el mapa porque no tienes conexión a internet.",
-        "confirmSiteCodeTitle": "Confirmar código de sitio",
-        "confirmSiteCodeDescription": "Confirme con su facilitador de brigada que el sitio que va a visitar corresponde al código del sitio {{code}}",
+        "confirmSiteNumberTitle": "Confirmar código de sitio",
+        "confirmSiteNumberDescription": "Confirme con su facilitador de brigada que el sitio que va a visitar corresponde al código del sitio {{code}}",
         "validation": {
           "siteCodeRegexError": "Este campo solo puede contener letras mayúsculas y números"
         }

--- a/assets/i18n/es-ES.json
+++ b/assets/i18n/es-ES.json
@@ -134,7 +134,6 @@
       "phone-tab": "Teléfono"
     },
     "validation": {
-      "invalidNumber": "Must be a number",
       "required": "Este campo es requerido",
       "requiredField": {
         "email": "El correo electrónico es requerido",
@@ -200,7 +199,12 @@
         "addressPlaceholder": "Escribe la dirección del sitio",
         "confirmLocation": "Confirmar ubicación",
         "noConnection": "No tienes conexión",
-        "noMapConnection": "No podemos cargar el mapa porque no tienes conexión a internet."
+        "noMapConnection": "No podemos cargar el mapa porque no tienes conexión a internet.",
+        "confirmSiteCodeTitle": "Confirmar código de sitio",
+        "confirmSiteCodeDescription": "Confirme con su facilitador de brigada que el sitio que va a visitar corresponde al código del sitio {{code}}",
+        "validation": {
+          "siteCodeRegexError": "Este campo solo puede contener letras mayúsculas y números"
+        }
       },
       "summary": {
         "siteStatus": "Estado del sitio",

--- a/assets/i18n/pt-PT.json
+++ b/assets/i18n/pt-PT.json
@@ -132,7 +132,6 @@
       "phone-tab": "Telefone"
     },
     "validation": {
-      "invalidNumber": "Deve ser um número",
       "required": "Campo obrigatório",
       "requiredField": {
         "email": "E-mail é obrigatório",
@@ -198,7 +197,12 @@
         "addressPlaceholder": "Digite o endereço do site",
         "confirmLocation": "Confirmar localização",
         "noConnection": "Você não tem conexão",
-        "noMapConnection": "Não podemos carregar o mapa porque você não tem conexão com a internet."
+        "noMapConnection": "Não podemos carregar o mapa porque você não tem conexão com a internet.",
+        "confirmSiteCodeTitle": "Confirmar código do site",
+        "confirmSiteCodeDescription": "Confirme com seu facilitador de brigada que o site que você vai visitar corresponde ao código do site {{code}}",
+        "validation": {
+          "siteCodeRegexError": "Este campo só pode conter letras maiúsculas e números."
+        }
       },
       "summary": {
         "siteStatus": "Status do local",

--- a/assets/i18n/pt-PT.json
+++ b/assets/i18n/pt-PT.json
@@ -198,8 +198,8 @@
         "confirmLocation": "Confirmar localização",
         "noConnection": "Você não tem conexão",
         "noMapConnection": "Não podemos carregar o mapa porque você não tem conexão com a internet.",
-        "confirmSiteCodeTitle": "Confirmar código do site",
-        "confirmSiteCodeDescription": "Confirme com seu facilitador de brigada que o site que você vai visitar corresponde ao código do site {{code}}",
+        "confirmSiteNumberTitle": "Confirmar código do site",
+        "confirmSiteNumberDescription": "Confirme com seu facilitador de brigada que o site que você vai visitar corresponde ao código do site {{code}}",
         "validation": {
           "siteCodeRegexError": "Este campo só pode conter letras maiúsculas e números."
         }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@expo/vector-icons": "^14.0.3",
     "@gorhom/bottom-sheet": "^4.6.4",
-    "@hookform/resolvers": "^3.9.0",
+    "@hookform/resolvers": "^4.1.2",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/netinfo": "11.3.1",
     "@react-native-picker/picker": "2.7.5",
@@ -57,7 +57,7 @@
     "nativewind": "^2.0.11",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-hook-form": "^7.52.2",
+    "react-hook-form": "^7.54.2",
     "react-i18next": "^14.1.2",
     "react-native": "0.74.5",
     "react-native-circular-progress-indicator": "^4.4.2",
@@ -75,7 +75,7 @@
     "react-native-toast-message": "^2.2.0",
     "react-native-web": "~0.19.10",
     "redux-devtools-expo-dev-plugin": "^0.2.1",
-    "zod": "^3.23.8",
+    "zod": "^3.24.2",
     "zustand": "^5.0.0-rc.2"
   },
   "devDependencies": {

--- a/schema/index.ts
+++ b/schema/index.ts
@@ -1,4 +1,4 @@
-import { TypeOf, object, z } from "zod";
+import { TypeOf, z } from "zod";
 import i18nInstance from "@/config/i18n";
 
 export const t = (key: string, args?: { [key: string]: string | number }) =>
@@ -58,20 +58,8 @@ export interface Team extends BaseObject {
   };
 }
 
-export const createHouseSchema = () => {
-  return object({
-    number: z.coerce.number({
-      required_error: t("validation.required"),
-      invalid_type_error: t("validation.invalidNumber"),
-    }),
-  });
-};
-
-const houseSchema = createHouseSchema();
-export type HouseInputType = TypeOf<typeof houseSchema>;
-
 export const createPostSchema = () => {
-  return object({
+  return z.object({
     content: z
       .string()
       .min(1, { message: t("validation.contentPostLengthMin") })
@@ -85,7 +73,7 @@ export type PostInputType = TypeOf<typeof postSchema>;
 export type PostVisibility = "public" | "team";
 
 export const createCommentSchema = () => {
-  return object({
+  return z.object({
     content: z
       .string()
       .min(1, { message: t("validation.contentCommentLengthMin") })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1289,10 +1289,12 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@hookform/resolvers@^3.9.0":
-  version "3.9.0"
-  resolved "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.9.0.tgz"
-  integrity sha512-bU0Gr4EepJ/EQsH/IwEzYLsT/PEj5C0ynLQ4m+GSHS+xKH4TfSelhluTgOaoc4kA5s7eCsQbM4wvZLzELmWzUg==
+"@hookform/resolvers@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-4.1.2.tgz#f2fe5ddc2341430a8559b53a8d5557b87e8636d4"
+  integrity sha512-wl6H9c9wLOZMJAqGLEVKzbCkxJuV+BYuLFZFCQtCwMe0b3qQk4kUBd/ZAj13SwcSqcx86rCgSCyngQfmA6DOWg==
+  dependencies:
+    "@standard-schema/utils" "^0.3.0"
 
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
@@ -2394,6 +2396,11 @@
   integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
+
+"@standard-schema/utils@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
+  integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
 
 "@svgr/babel-plugin-add-jsx-attribute@8.0.0":
   version "8.0.0"
@@ -8654,10 +8661,10 @@ react-freeze@^1.0.0:
   resolved "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz"
   integrity sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==
 
-react-hook-form@^7.52.2:
-  version "7.52.2"
-  resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.2.tgz"
-  integrity sha512-pqfPEbERnxxiNMPd0bzmt1tuaPcVccywFDpyk2uV5xCIBphHV5T8SVnX9/o3kplPE1zzKt77+YIoq+EMwJp56A==
+react-hook-form@^7.54.2:
+  version "7.54.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.54.2.tgz#8c26ed54c71628dff57ccd3c074b1dd377cfb211"
+  integrity sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==
 
 react-i18next@^14.1.2:
   version "14.1.2"
@@ -10891,10 +10898,15 @@ zod-validation-error@^2.1.0:
   resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-2.1.0.tgz#208eac75237dfed47c0018d2fe8fd03501bfc9ac"
   integrity sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==
 
-zod@^3.22.4, zod@^3.23.8:
+zod@^3.22.4:
   version "3.23.8"
   resolved "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz"
   integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
+
+zod@^3.24.2:
+  version "3.24.2"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.2.tgz#8efa74126287c675e92f46871cfc8d15c34372b3"
+  integrity sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==
 
 zustand@^5.0.0-rc.2:
   version "5.0.1"


### PR DESCRIPTION
[DNG-647](https://denguechat.atlassian.net/browse/DNG-647)

This PR adds a native alert as a confirmation before creating a new site. I'm also changing the old validation that only allowed numbers to an upper cased alphanumeric validation and bumping the `react-hook-form`, `@hookform/resolvers` and `zod` packages.