### PR TITLE
Use visit permission from the selected questions

### DIFF
--- a/app/(auth)/(tabs)/visits.tsx
+++ b/app/(auth)/(tabs)/visits.tsx
@@ -327,10 +327,6 @@ export default function Visits() {
 
   const snapPoints = useMemo(() => ["90%"], []);
 
-  const visitWasNotAllowedOrWasEarlyExit =
-    // @ts-expect-error
-    (selectedVisit?.answers ?? []).length === 1;
-
   return (
     <SafeAreaView>
       <ScrollView
@@ -422,8 +418,9 @@ export default function Visits() {
                         yellows={selectedVisit?.colorsAndQuantities?.YELLOW}
                         // @ts-expect-error
                         reds={selectedVisit?.colorsAndQuantities?.RED}
+                        // @ts-expect-error
                         permissionToVisitGranted={
-                          !visitWasNotAllowedOrWasEarlyExit
+                          selectedVisit?.visitPermission
                         }
                       />
                     )}

--- a/app/(auth)/(visit)/summary.tsx
+++ b/app/(auth)/(visit)/summary.tsx
@@ -92,12 +92,9 @@ export default function Summary() {
   let { mainStatusColor, colorsAndQuantities } =
     getColorsAndQuantities(inspections);
 
-  // if there's only one answer, there was a not allowed - early exit
-  const visitWasNotAllowedOrWasEarlyExit = answers.length === 1;
-
-  mainStatusColor = visitWasNotAllowedOrWasEarlyExit
-    ? StatusColor.PotentionallyInfected
-    : mainStatusColor;
+  mainStatusColor = visit.visitPermission
+    ? mainStatusColor
+    : StatusColor.PotentionallyInfected;
 
   const { createMutation: createVisit, loading } = useCreateMutation<
     { json_params: string },
@@ -116,7 +113,7 @@ export default function Summary() {
     const sanitizedVisitData = {
       ...visitData,
       house: visitData.houseId ? undefined : visitData.house,
-      visitPermission: !visitWasNotAllowedOrWasEarlyExit,
+      visitPermission: visit.visitPermission,
       host: visit.host,
       familyEducationTopics: visit.familyEducationTopics,
       visitedAt: new Date(),
@@ -195,7 +192,8 @@ export default function Summary() {
             yellows={colorsAndQuantities.YELLOW}
             reds={colorsAndQuantities.RED}
             color={mainStatusColor}
-            permissionToVisitGranted={!visitWasNotAllowedOrWasEarlyExit}
+            // @ts-expect-error
+            permissionToVisitGranted={visit.visitPermission}
           />
         </View>
       </ScrollView>

--- a/util/prepareFormData.ts
+++ b/util/prepareFormData.ts
@@ -126,6 +126,10 @@ export const prepareFormData = (formData: FormState) => {
         }
       }
 
+      if (resourceName === "visit_permission") {
+        visit.visitPermission = answer.bool;
+      }
+
       if (resourceName === "quantity_founded") {
         inspections[index][resourceName] = !!answer.text
           ? parseInt(answer.text) + 1


### PR DESCRIPTION
[DNG-925](https://denguechat.atlassian.net/browse/DNG-925)

This was causing a bug that I couldn't reproduce but our QA process caught it. Still, the right implementation would be to use the `bool` key from the question sent by the backend not just checking the lenght of the questions.